### PR TITLE
DS-970: Add Magic Nix Cache and other workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,19 +8,21 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@v1
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Check nixpkgs-fmt formatting
         run: .github/workflows/fmt.sh
 
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: DeterminateSystems/nix-installer-action@v1
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Run build
         run: nix-build


### PR DESCRIPTION
 An assortment of GitHub Workflow changes, potentially including:

- Enable DeterminateSystems/magic-nix-cache-action@main
- Reference all DeterminateSystems actions via @main
- Make update.yaml consistent across repos
- Remove unnecessary github-token: from nix-installer-action
- Update actions/checkout@v2 to actions/checkout@v3
